### PR TITLE
graphql-exporter: add api token env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ graphql_exporter_custom_fields_memory_total{name="server",order_contract_id="con
 # TYPE graphql_exporter_custom_fields_price gauge
 graphql_exporter_custom_fields_price{name="server",order_contract_id="contract-nr1"} 7408.8
 ```
+
+API token can be overridden with `GRAPHQLAPITOKEN` env variable.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,11 @@ func Init(configPath string) error {
 	if err != nil {
 		return err
 	}
+	val, isSet := os.LookupEnv("GRAPHQLAPITOKEN")
+	if isSet {
+		Config.GraphqlAPIToken = val
+	}
+
 	log.Printf("Finished reading config.")
 	return nil
 }


### PR DESCRIPTION
Add ability to override API  token from config with ENV variable.

@vinted/sre 