### PR TITLE
Configure if should retry metrics retrieval on error.

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -2,6 +2,7 @@
   "graphqlURL": "http://localhost:8090/graphql/",
   "graphqlAPIToken": "Token SECRET",
   "cacheExpire": 0,
+  "retryOnError": false,
   "metricsPrefix": "graphql_exporter_",
   "queries":[
     {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Cfg struct {
 	GraphqlURL      string
 	GraphqlAPIToken string
 	CacheExpire     int64
+	RetryOnError    bool
 	MetricsPrefix   string
 	Queries         []Query
 }


### PR DESCRIPTION
Configure if should retry data retrieval on error. 

If yes, then won't update `cachedAt` value and the next scrape will initiate another attempt to retrieve data. If, on the other hand, we don't want to retry and we are fine with stale data, then `cachedAt` will be updated even after error, and another attempt to refresh data will come only after cache expiration period.