### PR TITLE
Best effort retrieval with timeouts

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,10 +1,10 @@
 {
+  "metricsPrefix": "graphql_exporter_",
   "graphqlURL": "http://localhost:8090/graphql/",
   "graphqlAPIToken": "Token SECRET",
   "cacheExpire": 0,
-  "timeout": 60,
+  "queryTimeout": 60,
   "retryOnError": false,
-  "metricsPrefix": "graphql_exporter_",
   "queries":[
     {
       "query": "query {device_list {name serial custom_fields}} {{NOW \"-1h\"}}",

--- a/config_example.json
+++ b/config_example.json
@@ -2,6 +2,7 @@
   "graphqlURL": "http://localhost:8090/graphql/",
   "graphqlAPIToken": "Token SECRET",
   "cacheExpire": 0,
+  "timeout": 60,
   "retryOnError": false,
   "metricsPrefix": "graphql_exporter_",
   "queries":[

--- a/config_example.json
+++ b/config_example.json
@@ -4,7 +4,8 @@
   "graphqlAPIToken": "Token SECRET",
   "cacheExpire": 0,
   "queryTimeout": 60,
-  "retryOnError": false,
+  "failFast": false,
+  "extendCacheOnError": false,
   "queries":[
     {
       "query": "query {device_list {name serial custom_fields}} {{NOW \"-1h\"}}",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Cfg struct {
 	GraphqlURL      string
 	GraphqlAPIToken string
 	CacheExpire     int64
+	Timeout         int64
 	RetryOnError    bool
 	MetricsPrefix   string
 	Queries         []Query
@@ -55,6 +56,10 @@ func Init(configPath string) error {
 	val, isSet := os.LookupEnv("GRAPHQLAPITOKEN")
 	if isSet {
 		Config.GraphqlAPIToken = val
+	}
+
+	if Config.Timeout == 0 {
+		Config.Timeout = 60
 	}
 
 	slog.Info(fmt.Sprintf("Finished reading config from %s", configPath))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ type Cfg struct {
 	GraphqlURL      string
 	GraphqlAPIToken string
 	CacheExpire     int64
-	Timeout         int64
+	QueryTimeout    int64
 	RetryOnError    bool
 	MetricsPrefix   string
 	Queries         []Query
@@ -58,8 +58,8 @@ func Init(configPath string) error {
 		Config.GraphqlAPIToken = val
 	}
 
-	if Config.Timeout == 0 {
-		Config.Timeout = 60
+	if Config.QueryTimeout == 0 {
+		Config.QueryTimeout = 60
 	}
 
 	slog.Info(fmt.Sprintf("Finished reading config from %s", configPath))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,13 +8,14 @@ import (
 )
 
 type Cfg struct {
-	GraphqlURL      string
-	GraphqlAPIToken string
-	CacheExpire     int64
-	QueryTimeout    int64
-	RetryOnError    bool
-	MetricsPrefix   string
-	Queries         []Query
+	MetricsPrefix      string
+	GraphqlURL         string
+	GraphqlAPIToken    string
+	CacheExpire        int64
+	QueryTimeout       int64
+	FailFast           bool
+	ExtendCacheOnError bool
+	Queries            []Query
 }
 
 type Query struct {

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -114,17 +114,21 @@ func buildLabelData(val interface{}, m config.Metric) (map[string]string, error)
 	return metric.Labels, error_in_hash
 }
 
-func (collector *GraphqlCollector) getMetrics(ctx context.Context) ([]Metric, error) {
+func (collector *GraphqlCollector) getMetrics() ([]Metric, error) {
 	var gql *Graphql
 	var metrics []Metric
 	for _, q := range config.Config.Queries {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(config.Config.QueryTimeout))
 		result, err := graphql.GraphqlQuery(ctx, q.Query)
+		cancel()
 		if err != nil {
-			return nil, fmt.Errorf("query error: %s", err)
+			slog.Error(fmt.Sprintf("query error: %s", err))
+			continue
 		}
 		err = json.Unmarshal(result, &gql)
 		if err != nil {
-			return nil, fmt.Errorf("unmarshal error: %s", err)
+			slog.Error(fmt.Sprintf("unmarshal error: %s", err))
+			continue
 		}
 		data := gql.Data.(map[string]interface{})
 		for _, m := range q.Metrics {
@@ -137,13 +141,13 @@ func (collector *GraphqlCollector) getMetrics(ctx context.Context) ([]Metric, er
 				// loop through value path from config. extract result
 				metric.ValueName, metric.Value, error_in_hash = buildValueData(val_hash, m.Value)
 				if error_in_hash != nil {
-					slog.Error(fmt.Sprintf("got error: %s", error_in_hash))
+					slog.Error(fmt.Sprintf("metric value build error: %s", error_in_hash))
 					continue
 				}
 				// loop through labels from config. Build label-value keypairs.
 				metric.Labels, error_in_hash = buildLabelData(val, m)
 				if error_in_hash != nil {
-					slog.Error(fmt.Sprintf("got error: %s", error_in_hash))
+					slog.Error(fmt.Sprintf("metric labels build error: %s", error_in_hash))
 					continue
 				}
 				metric.Name = config.Config.MetricsPrefix + strings.Replace(m.Value, ",", "_", -1)
@@ -158,9 +162,7 @@ func (collector *GraphqlCollector) Describe(ch chan<- *prometheus.Desc) {}
 
 func (collector *GraphqlCollector) updateMetrics() error {
 	if time.Now().Unix()-collector.cachedAt > config.Config.CacheExpire {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(config.Config.Timeout))
-		defer cancel()
-		metrics, err := collector.getMetrics(ctx)
+		metrics, err := collector.getMetrics()
 		collector.accessMu.Lock()
 		defer collector.accessMu.Unlock()
 		if err != nil {

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -158,7 +158,7 @@ func (collector *GraphqlCollector) Describe(ch chan<- *prometheus.Desc) {}
 
 func (collector *GraphqlCollector) updateMetrics() error {
 	if time.Now().Unix()-collector.cachedAt > config.Config.CacheExpire {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(config.Config.Timeout))
 		defer cancel()
 		metrics, err := collector.getMetrics(ctx)
 		collector.accessMu.Lock()


### PR DESCRIPTION
More configuration:

* Timeout for individual GraphQL query (default is 60 seconds)
* Configure if should fail fast (return error if any single query fails) or should continue to get best effort results (some queries may fail, others - not)
* Change `retryOnError` to `extendCacheOnError` with opposite meaning for better clarity on what it means (still not ideal, though)