### PR TITLE
Add support for metric name and constant integer value

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Metric struct {
 	Placeholder string
 	Labels      []string
 	Value       string
+	Name        string
 }
 
 var (


### PR DESCRIPTION
Add support for constant metric value and metric name. Example - we want to export inventory with no specific value, basically for labels only. 

We can achieve this with:

```json
      "query": "...",
      "metrics": [
        {
          "description": "...",
          "placeholder": "...",
          "labels": [
            "...",
            "..."
          ],
          "value": "1",
          "name": "foobar"
        }
```

In this case, metric will be named `<prefix>_foobar`, and its value will be `1`.

Also, simplify code - remove some unused structs and values.